### PR TITLE
Improve MoveIt actions and async waits

### DIFF
--- a/mofpy/README.md
+++ b/mofpy/README.md
@@ -128,9 +128,10 @@ MoveGroupの名前付き目標姿勢を実行します
 
 #### Parameters
 
-| key         | type   | description                       |
-| ----------- | ------ | --------------------------------- |
-| target_name | string | MoveGroupの名前付き目標姿勢の名前 |
+| key             | type        | description                                                      |
+| --------------- | ----------- | ---------------------------------------------------------------- |
+| target_name     | string      | MoveGroupの名前付き目標姿勢の名前                               |
+| time_from_start | float (opt) | 軌道終端時刻[s]を上書きする。指定時は計画軌道全体の時間を再スケール |
 
 #### Example
 
@@ -141,6 +142,7 @@ ready:
   action:
     - type: moveit_named_target
       target_name: ready
+      time_from_start: 8.0
 ```
 
 ### moveit_partial_joint

--- a/mofpy/mofpy/action/flipper_effort_control.py
+++ b/mofpy/mofpy/action/flipper_effort_control.py
@@ -1,5 +1,6 @@
 import re
 import threading
+import time
 import uuid
 
 from controller_manager_msgs.msg import ControllerState
@@ -115,7 +116,11 @@ class FlipperEffortControl(Action):
         # コントローラの一覧を取得
         req = ListControllers.Request()
         self.lc_future = self.__list_controller_client.call_async(req)
-        self.executor.spin_until_future_complete(future=self.lc_future, timeout_sec=1)
+        if not self.__wait_future__(self.lc_future, timeout_sec=1.0):
+            rclpy.logging.get_logger("mofpy.FlipperEffortControl").error(
+                "Timed out waiting for controller list"
+            )
+            return None
 
         res: ListControllers.Response = self.lc_future.result()
         if res is None:
@@ -149,7 +154,11 @@ class FlipperEffortControl(Action):
         req.strictness = SwitchController.Request.BEST_EFFORT
 
         self.sc_future = self.__switch_controller_client.call_async(req)
-        self.executor.spin_until_future_complete(future=self.sc_future, timeout_sec=1)
+        if not self.__wait_future__(self.sc_future, timeout_sec=1.0):
+            rclpy.logging.get_logger("mofpy.FlipperEffortControl").error(
+                "Timed out waiting for controller switch"
+            )
+            return False
 
         res: SwitchController.Response = self.sc_future.result()
         if res is None:
@@ -168,6 +177,14 @@ class FlipperEffortControl(Action):
         msg = Float64MultiArray()
         msg.data = joint_efforts
         self.__flipper_pub.publish(msg)
+
+    def __wait_future__(self, future, timeout_sec: float) -> bool:
+        deadline = time.monotonic() + timeout_sec
+        while rclpy.ok() and time.monotonic() < deadline:
+            if future.done():
+                return True
+            time.sleep(0.01)
+        return future.done()
 
 
 Action.register_preset(FlipperEffortControl)

--- a/mofpy/mofpy/action/flipper_position_control.py
+++ b/mofpy/mofpy/action/flipper_position_control.py
@@ -1,5 +1,6 @@
 import re
 import threading
+import time
 import uuid
 
 from controller_manager_msgs.msg import ControllerState
@@ -117,7 +118,11 @@ class FlipperPositionControl(Action):
         # コントローラの一覧を取得
         req = ListControllers.Request()
         self.lc_future = self.__list_controller_client.call_async(req)
-        self.executor.spin_until_future_complete(future=self.lc_future, timeout_sec=1)
+        if not self.__wait_future__(self.lc_future, timeout_sec=1.0):
+            rclpy.logging.get_logger("mofpy.FlipperPositionControl").error(
+                "Timed out waiting for controller list"
+            )
+            return None
 
         res: ListControllers.Response = self.lc_future.result()
         if res is None:
@@ -151,7 +156,11 @@ class FlipperPositionControl(Action):
         req.strictness = SwitchController.Request.BEST_EFFORT
 
         self.sc_future = self.__switch_controller_client.call_async(req)
-        self.executor.spin_until_future_complete(future=self.sc_future, timeout_sec=1)
+        if not self.__wait_future__(self.sc_future, timeout_sec=1.0):
+            rclpy.logging.get_logger("mofpy.FlipperPositionControl").error(
+                "Timed out waiting for controller switch"
+            )
+            return False
 
         res: SwitchController.Response = self.sc_future.result()
         if res is None:
@@ -170,6 +179,14 @@ class FlipperPositionControl(Action):
         msg = Float64MultiArray()
         msg.data = joint_positions
         self.__flipper_pub.publish(msg)
+
+    def __wait_future__(self, future, timeout_sec: float) -> bool:
+        deadline = time.monotonic() + timeout_sec
+        while rclpy.ok() and time.monotonic() < deadline:
+            if future.done():
+                return True
+            time.sleep(0.01)
+        return future.done()
 
 
 Action.register_preset(FlipperPositionControl)

--- a/mofpy/mofpy/action/flipper_velocity_control.py
+++ b/mofpy/mofpy/action/flipper_velocity_control.py
@@ -1,5 +1,6 @@
 import re
 import threading
+import time
 import uuid
 
 from controller_manager_msgs.msg import ControllerState
@@ -195,7 +196,11 @@ class FlipperVelocityControl(Action):
         # コントローラの一覧を取得
         req = ListControllers.Request()
         self.lc_future = self.__list_controller_client.call_async(req)
-        self.executor.spin_until_future_complete(future=self.lc_future, timeout_sec=1)
+        if not self.__wait_future__(self.lc_future, timeout_sec=1.0):
+            rclpy.logging.get_logger("mofpy.FlipperVelocityControl").error(
+                "Timed out waiting for controller list"
+            )
+            return None
 
         res: ListControllers.Response = self.lc_future.result()
         if res is None:
@@ -229,7 +234,11 @@ class FlipperVelocityControl(Action):
         req.strictness = SwitchController.Request.BEST_EFFORT
 
         self.sc_future = self.__switch_controller_client.call_async(req)
-        self.executor.spin_until_future_complete(future=self.sc_future, timeout_sec=1)
+        if not self.__wait_future__(self.sc_future, timeout_sec=1.0):
+            rclpy.logging.get_logger("mofpy.FlipperVelocityControl").error(
+                "Timed out waiting for controller switch"
+            )
+            return False
 
         res: SwitchController.Response = self.sc_future.result()
         if res is None:
@@ -239,6 +248,14 @@ class FlipperVelocityControl(Action):
             return False
 
         return res.ok
+
+    def __wait_future__(self, future, timeout_sec: float) -> bool:
+        deadline = time.monotonic() + timeout_sec
+        while rclpy.ok() and time.monotonic() < deadline:
+            if future.done():
+                return True
+            time.sleep(0.01)
+        return future.done()
 
     # マッピングを取得
     def __get_mapping__(self):

--- a/mofpy/mofpy/action/moveit_named_target.py
+++ b/mofpy/mofpy/action/moveit_named_target.py
@@ -25,6 +25,7 @@ class MoveitNamedTarget(Action):
         self.__planner = MoveGroupUtils.planner
         self.__executor = MoveGroupUtils.executor
         self.__target_name = self.get_required("target_name")
+        self.__time_from_start = self.get("time_from_start", None)
 
     def execute(self, named_joy=None):
         if Shared.get("move_group_disabled"):
@@ -52,7 +53,72 @@ class MoveitNamedTarget(Action):
         plan = self.__planner.plan()
 
         if plan:
+            self.__retime_trajectory(plan.trajectory)
             self.__moveit.execute(plan.trajectory, controllers=[])
+
+    def __retime_trajectory(self, trajectory):
+        logger = rclpy.logging.get_logger("mofpy.MoveitNamedTarget")
+
+        if self.__time_from_start is None:
+            return
+
+        if (
+            not isinstance(self.__time_from_start, (int, float))
+            or float(self.__time_from_start) <= 0.0
+        ):
+            logger.error(
+                "Invalid time_from_start '{}'. Must be > 0.0 [s].".format(self.__time_from_start)
+            )
+            return
+
+        traj_msg = trajectory.get_robot_trajectory_msg()
+        points = traj_msg.joint_trajectory.points
+        if not points:
+            logger.warn("No joint trajectory points to retime")
+            return
+
+        current_last = self.__duration_to_sec(points[-1].time_from_start)
+        target_last = float(self.__time_from_start)
+        if current_last <= 0.0:
+            logger.warn("Current trajectory duration is 0; skip retiming")
+            return
+
+        ratio = target_last / current_last
+        for p in points:
+            t = self.__duration_to_sec(p.time_from_start)
+            self.__set_duration_from_sec(p.time_from_start, t * ratio)
+            # Keep derivatives consistent with retimed timestamps.
+            # If time is scaled by ratio, velocity should be 1/ratio and
+            # acceleration should be 1/ratio^2.
+            if p.velocities:
+                p.velocities = [v / ratio for v in p.velocities]
+            if p.accelerations:
+                p.accelerations = [a / (ratio * ratio) for a in p.accelerations]
+
+        planning_scene_monitor = self.__moveit.get_planning_scene_monitor()
+        with planning_scene_monitor.read_only() as scene:
+            current_state = scene.current_state
+            trajectory.set_robot_trajectory_msg(current_state, traj_msg)
+
+        logger.info(
+            "Retimed named target '{}' from {:.3f}s to {:.3f}s (x{:.3f})".format(
+                self.__target_name, current_last, target_last, ratio
+            )
+        )
+
+    @staticmethod
+    def __duration_to_sec(duration):
+        return float(duration.sec) + float(duration.nanosec) / 1e9
+
+    @staticmethod
+    def __set_duration_from_sec(duration, sec_float):
+        sec_int = int(sec_float)
+        nanosec = int(round((sec_float - sec_int) * 1e9))
+        if nanosec >= 1_000_000_000:
+            sec_int += 1
+            nanosec -= 1_000_000_000
+        duration.sec = sec_int
+        duration.nanosec = nanosec
 
 
 Action.register_preset(MoveitNamedTarget)

--- a/mofpy/mofpy/action/moveit_servo_joint.py
+++ b/mofpy/mofpy/action/moveit_servo_joint.py
@@ -1,4 +1,5 @@
 import threading
+import time
 
 from control_msgs.msg import JointJog
 from moveit_msgs.srv import ServoCommandType
@@ -79,7 +80,11 @@ class MoveitServoJoint(Action):
         )
 
         self.future = self.__client.call_async(req)
-        self.executor.spin_until_future_complete(future=self.future, timeout_sec=1)
+        if not self.__wait_future__(self.future, timeout_sec=1.0):
+            rclpy.logging.get_logger("moveit_servo_joint_jog").error(
+                "timed out waiting for {}".format(self.__client.service_name)
+            )
+            return False
 
         res: ServoCommandType.Response = self.future.result()
 
@@ -96,6 +101,14 @@ class MoveitServoJoint(Action):
             Shared.update("moveit_servo_command_type", ServoCommandType.Request.JOINT_JOG)
 
         return res.success
+
+    def __wait_future__(self, future, timeout_sec: float) -> bool:
+        deadline = time.monotonic() + timeout_sec
+        while rclpy.ok() and time.monotonic() < deadline:
+            if future.done():
+                return True
+            time.sleep(0.01)
+        return future.done()
 
     def __get_jog_joints__(self, named_buttons, named_axes):
         msg = JointJog()

--- a/mofpy/mofpy/action/moveit_servo_twist.py
+++ b/mofpy/mofpy/action/moveit_servo_twist.py
@@ -1,4 +1,5 @@
 import threading
+import time
 
 from geometry_msgs.msg import Twist
 from geometry_msgs.msg import TwistStamped
@@ -23,7 +24,7 @@ class MoveitServoTwist(Action):
 
         self.__frame_id = self.get("frame_id", "base_link")
         self.__scale_trn = self.get("scale/translation", 0.1)
-        self.__scale_rot = self.get("scale/rotation", 0.01)
+        self.__scale_rot = self.get("scale/rotation", 0.1)
         self.__quiet_on_zero = self.get("quiet_on_zero", True)
         self.__mapping = self.__mapping__()
         self.__published_zero = False
@@ -80,7 +81,11 @@ class MoveitServoTwist(Action):
         )
 
         self.future = self.__client.call_async(req)
-        self.executor.spin_until_future_complete(future=self.future, timeout_sec=1)
+        if not self.__wait_future__(self.future, timeout_sec=1.0):
+            rclpy.logging.get_logger("moveit_servo_twist").error(
+                "timed out waiting for {}".format(self.__client.service_name)
+            )
+            return False
 
         res: ServoCommandType.Response = self.future.result()
 
@@ -97,6 +102,14 @@ class MoveitServoTwist(Action):
             Shared.update("moveit_servo_command_type", ServoCommandType.Request.TWIST)
 
         return res.success
+
+    def __wait_future__(self, future, timeout_sec: float) -> bool:
+        deadline = time.monotonic() + timeout_sec
+        while rclpy.ok() and time.monotonic() < deadline:
+            if future.done():
+                return True
+            time.sleep(0.01)
+        return future.done()
 
     def __get_twist__(self, named_axes):
         dx = self.__scale_trn * self.__get_value__("x", named_axes)


### PR DESCRIPTION
## 説明

非同期 service 呼び出しの待ち方を修正
flipper_velocity_control、flipper_position_control、flipper_effort_control、moveit_servo_joint、moveit_servo_twist で、別 thread で回している executor に対して spin_until_future_complete() を再入していた処理をやめました。Executor is already spinning で mofpy_node が落ちる問題の修正です。onix_joy.launch.py で chassis/arm モード切替時に落ちていた原因に対応しています。

named target の実行時間を上書きできるようにした
moveit_named_target に time_from_start を追加し、指定時は計画軌道全体をその時間に合わせて再タイミングするようにしました。これに合わせて README に新パラメータの説明と例を追加しています。

## 実施したテスト
実機で動作確認

## システム動作への影響

多分該当なし。

## インターフェースの変更
多分該当なし
